### PR TITLE
refactor: MVVM refactor + ViewModels + LeakCanary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,7 @@ dependencies {
     implementation(libs.core.splashscreen)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    debugImplementation(libs.leakcanary)
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.konsist)

--- a/app/src/debug/java/de/lemke/oneuisample/DebugTools.kt
+++ b/app/src/debug/java/de/lemke/oneuisample/DebugTools.kt
@@ -1,0 +1,6 @@
+package de.lemke.oneuisample
+
+import android.content.Context
+import leakcanary.LeakCanary
+
+fun openLeakCanary(context: Context) = context.startActivity(LeakCanary.newLeakDisplayActivityIntent())

--- a/app/src/debug/res/values/leak_canary.xml
+++ b/app/src/debug/res/values/leak_canary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="leak_canary_add_launcher_icon"
+        tools:ignore="UnusedResources">false</bool>
+</resources>

--- a/app/src/main/java/de/lemke/oneuisample/domain/AcceptTosUseCase.kt
+++ b/app/src/main/java/de/lemke/oneuisample/domain/AcceptTosUseCase.kt
@@ -18,8 +18,12 @@ class AcceptTosUseCase @Inject constructor(
         versionCode: Int,
         versionName: String,
     ) = withContext(Dispatchers.Default) {
-        userSettings.acceptedTosVersion = context.resources.getInteger(R.integer.tos_version)
-        userSettings.lastVersionCode = versionCode
-        userSettings.lastVersionName = versionName
+        userSettings.update {
+            copy(
+                acceptedTosVersion = context.resources.getInteger(R.integer.tos_version),
+                lastVersionCode = versionCode,
+                lastVersionName = versionName,
+            )
+        }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/domain/AcceptTosUseCase.kt
+++ b/app/src/main/java/de/lemke/oneuisample/domain/AcceptTosUseCase.kt
@@ -1,0 +1,25 @@
+package de.lemke.oneuisample.domain
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import de.lemke.oneuisample.R
+import de.lemke.oneuisample.data.UserSettingsRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Singleton
+class AcceptTosUseCase @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val userSettings: UserSettingsRepository,
+) {
+    suspend operator fun invoke(
+        versionCode: Int,
+        versionName: String,
+    ) = withContext(Dispatchers.Default) {
+        userSettings.acceptedTosVersion = context.resources.getInteger(R.integer.tos_version)
+        userSettings.lastVersionCode = versionCode
+        userSettings.lastVersionName = versionName
+    }
+}

--- a/app/src/main/java/de/lemke/oneuisample/domain/CompleteOnboardingUseCase.kt
+++ b/app/src/main/java/de/lemke/oneuisample/domain/CompleteOnboardingUseCase.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @Singleton
-class AcceptTosUseCase @Inject constructor(
+class CompleteOnboardingUseCase @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val userSettings: UserSettingsRepository,
 ) {

--- a/app/src/main/java/de/lemke/oneuisample/ui/AboutActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AboutActivity.kt
@@ -27,19 +27,19 @@ import dev.oneuiproject.oneui.design.R as designR
 class AboutActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAboutBinding
     private val viewModel: AboutViewModel by viewModels()
+    private lateinit var versionTextView: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityAboutBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        versionTextView = binding.appInfoLayout.findViewById(designR.id.app_info_version)
         binding.appInfoLayout.apply {
             addOptionalText("Extra 1")
             addOptionalText("Extra 2")
             setMainButtonClickListener { suggestiveSnackBar("Main button clicked! updateState: $updateStatus") }
         }
-        binding.appInfoLayout.findViewById<TextView>(designR.id.app_info_version).onMultiClick {
-            viewModel.onToggleDevMode()
-        }
+        versionTextView.onMultiClick { viewModel.onToggleDevMode() }
         binding.aboutButtonStatus.setOnClickListener { changeStatus() }
         binding.aboutButtonGithub.setOnClickListener { openURL(getString(R.string.link_oneui_design)) }
         binding.aboutButtonOpenSourceLicenses.setOnClickListener { startActivity(Intent(this, LibsActivity::class.java)) }
@@ -47,7 +47,7 @@ class AboutActivity : AppCompatActivity() {
     }
 
     private fun render(state: AboutUiState) {
-        binding.appInfoLayout.findViewById<TextView>(designR.id.app_info_version).text =
+        versionTextView.text =
             getString(designR.string.oui_des_version_info, VERSION_NAME + if (state.devModeEnabled) " (dev)" else "")
     }
 

--- a/app/src/main/java/de/lemke/oneuisample/ui/AboutActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AboutActivity.kt
@@ -3,12 +3,13 @@ package de.lemke.oneuisample.ui
 import android.content.Intent
 import android.os.Bundle
 import android.widget.TextView
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.BuildConfig.VERSION_NAME
 import de.lemke.oneuisample.R
-import de.lemke.oneuisample.data.UserSettingsRepository
 import de.lemke.oneuisample.databinding.ActivityAboutBinding
+import de.lemke.oneuisample.ui.util.collectState
 import de.lemke.oneuisample.ui.util.openURL
 import de.lemke.oneuisample.ui.util.suggestiveSnackBar
 import dev.oneuiproject.oneui.ktx.onMultiClick
@@ -20,15 +21,12 @@ import dev.oneuiproject.oneui.layout.AppInfoLayout.Status.NotUpdatable
 import dev.oneuiproject.oneui.layout.AppInfoLayout.Status.Unset
 import dev.oneuiproject.oneui.layout.AppInfoLayout.Status.UpdateAvailable
 import dev.oneuiproject.oneui.layout.AppInfoLayout.Status.UpdateDownloaded
-import javax.inject.Inject
 import dev.oneuiproject.oneui.design.R as designR
 
 @AndroidEntryPoint
 class AboutActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAboutBinding
-
-    @Inject
-    lateinit var userSettings: UserSettingsRepository
+    private val viewModel: AboutViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,23 +37,18 @@ class AboutActivity : AppCompatActivity() {
             addOptionalText("Extra 2")
             setMainButtonClickListener { suggestiveSnackBar("Main button clicked! updateState: $updateStatus") }
         }
-        val version: TextView = binding.appInfoLayout.findViewById(designR.id.app_info_version)
-        setVersionTextView(version, userSettings.devModeEnabled)
-        version.onMultiClick {
-            val newDevModeEnabled = !userSettings.devModeEnabled
-            userSettings.devModeEnabled = newDevModeEnabled
-            setVersionTextView(version, newDevModeEnabled)
+        binding.appInfoLayout.findViewById<TextView>(designR.id.app_info_version).onMultiClick {
+            viewModel.onToggleDevMode()
         }
         binding.aboutButtonStatus.setOnClickListener { changeStatus() }
         binding.aboutButtonGithub.setOnClickListener { openURL(getString(R.string.link_oneui_design)) }
         binding.aboutButtonOpenSourceLicenses.setOnClickListener { startActivity(Intent(this, LibsActivity::class.java)) }
+        collectState(viewModel.state) { render(it) }
     }
 
-    private fun setVersionTextView(
-        textView: TextView,
-        devModeEnabled: Boolean,
-    ) {
-        textView.text = getString(designR.string.oui_des_version_info, VERSION_NAME + if (devModeEnabled) " (dev)" else "")
+    private fun render(state: AboutUiState) {
+        binding.appInfoLayout.findViewById<TextView>(designR.id.app_info_version).text =
+            getString(designR.string.oui_des_version_info, VERSION_NAME + if (state.devModeEnabled) " (dev)" else "")
     }
 
     fun changeStatus() {

--- a/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
@@ -28,6 +28,6 @@ class AboutViewModel @Inject constructor(
             )
 
     fun onToggleDevMode() {
-        userSettings.devModeEnabled = !userSettings.devModeEnabled
+        userSettings.update { copy(devModeEnabled = !devModeEnabled) }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
@@ -1,0 +1,28 @@
+package de.lemke.oneuisample.ui
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lemke.oneuisample.data.UserSettingsRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class AboutUiState(
+    val devModeEnabled: Boolean = false,
+)
+
+@HiltViewModel
+class AboutViewModel @Inject constructor(
+    private val userSettings: UserSettingsRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(AboutUiState(devModeEnabled = userSettings.devModeEnabled))
+    val state: StateFlow<AboutUiState> = _state.asStateFlow()
+
+    fun onToggleDevMode() {
+        val newValue = !userSettings.devModeEnabled
+        userSettings.devModeEnabled = newValue
+        _state.update { it.copy(devModeEnabled = newValue) }
+    }
+}

--- a/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
@@ -1,13 +1,14 @@
 package de.lemke.oneuisample.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.data.UserSettingsRepository
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 data class AboutUiState(
     val devModeEnabled: Boolean = false,
@@ -17,12 +18,16 @@ data class AboutUiState(
 class AboutViewModel @Inject constructor(
     private val userSettings: UserSettingsRepository,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(AboutUiState(devModeEnabled = userSettings.devModeEnabled))
-    val state: StateFlow<AboutUiState> = _state.asStateFlow()
+    val state: StateFlow<AboutUiState> =
+        userSettings.flow
+            .map { AboutUiState(devModeEnabled = it.devModeEnabled) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = AboutUiState(devModeEnabled = userSettings.devModeEnabled),
+            )
 
     fun onToggleDevMode() {
-        val newValue = !userSettings.devModeEnabled
-        userSettings.devModeEnabled = newValue
-        _state.update { it.copy(devModeEnabled = newValue) }
+        userSettings.devModeEnabled = !userSettings.devModeEnabled
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AboutViewModel.kt
@@ -4,11 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.data.UserSettingsRepository
+import de.lemke.oneuisample.ui.util.stateInViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 
 data class AboutUiState(
     val devModeEnabled: Boolean = false,
@@ -21,11 +20,7 @@ class AboutViewModel @Inject constructor(
     val state: StateFlow<AboutUiState> =
         userSettings.flow
             .map { AboutUiState(devModeEnabled = it.devModeEnabled) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = AboutUiState(devModeEnabled = userSettings.devModeEnabled),
-            )
+            .stateInViewModel(viewModelScope, AboutUiState(devModeEnabled = userSettings.devModeEnabled))
 
     fun onToggleDevMode() {
         userSettings.update { copy(devModeEnabled = !devModeEnabled) }

--- a/app/src/main/java/de/lemke/oneuisample/ui/AppPickerActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AppPickerActivity.kt
@@ -5,6 +5,7 @@ import android.graphics.ColorFilter
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -23,9 +24,9 @@ import com.airbnb.lottie.model.KeyPath
 import com.airbnb.lottie.value.LottieValueCallback
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.R
-import de.lemke.oneuisample.data.UserSettingsRepository
 import de.lemke.oneuisample.databinding.ActivityAppPickerBinding
 import de.lemke.oneuisample.ui.util.ListTypes
+import de.lemke.oneuisample.ui.util.collectState
 import de.lemke.oneuisample.ui.util.suggestiveSnackBar
 import dev.oneuiproject.oneui.delegates.AppBarAwareYTranslator
 import dev.oneuiproject.oneui.delegates.ViewYTranslator
@@ -34,16 +35,13 @@ import dev.oneuiproject.oneui.ktx.setEntries
 import dev.oneuiproject.oneui.layout.ToolbarLayout.SearchModeOnBackBehavior.CLEAR_DISMISS
 import dev.oneuiproject.oneui.layout.startSearchMode
 import dev.oneuiproject.oneui.recyclerview.ktx.seslSetFastScrollerAdditionalPadding
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppPickerActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTranslator() {
     private lateinit var binding: ActivityAppPickerBinding
+    private val viewModel: AppPickerViewModel by viewModels()
     private val packageManagerHelper by lazy { AppPickerContext(this).packageManagerHelper }
     private var currentPicker: SeslAppPickerView? = null
-
-    @Inject
-    lateinit var userSettings: UserSettingsRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,6 +49,7 @@ class AppPickerActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
         setContentView(binding.root)
         initSpinner()
         binding.noEntryView.translateYWithAppBar(binding.toolbarLayout.appBarLayout, this)
+        collectState(viewModel.state) { render(it) }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean = menuInflater.inflate(R.menu.app_picker, menu).let { true }
@@ -84,13 +83,14 @@ class AppPickerActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
     private fun initSpinner() {
         binding.appPickerSpinner.apply {
             setEntries(ListTypes.entries.map { getString(it.description) }) { pos, _ ->
-                pos?.let { type ->
-                    setAppPickerType(ListTypes.entries[type])
-                    userSettings.appPickerType = type
-                }
+                pos?.let { viewModel.onPickerTypeChanged(it) }
             }
-            setSelection(userSettings.appPickerType)
+            setSelection(viewModel.state.value.pickerType)
         }
+    }
+
+    private fun render(state: AppPickerUiState) {
+        setAppPickerType(ListTypes.entries[state.pickerType])
     }
 
     private fun configureAppPicker(appPicker: SeslAppPickerView) {

--- a/app/src/main/java/de/lemke/oneuisample/ui/AppPickerActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AppPickerActivity.kt
@@ -89,8 +89,12 @@ class AppPickerActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
         }
     }
 
+    private var renderedPickerType = -1
+
     private fun render(state: AppPickerUiState) {
-        setAppPickerType(ListTypes.entries[state.pickerType])
+        if (renderedPickerType == state.pickerType) return
+        renderedPickerType = state.pickerType
+        setAppPickerType(ListTypes.entries.getOrElse(state.pickerType) { ListTypes.entries.first() })
     }
 
     private fun configureAppPicker(appPicker: SeslAppPickerView) {

--- a/app/src/main/java/de/lemke/oneuisample/ui/AppPickerViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AppPickerViewModel.kt
@@ -1,0 +1,27 @@
+package de.lemke.oneuisample.ui
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lemke.oneuisample.data.UserSettingsRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class AppPickerUiState(
+    val pickerType: Int = 0,
+)
+
+@HiltViewModel
+class AppPickerViewModel @Inject constructor(
+    private val userSettings: UserSettingsRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(AppPickerUiState(pickerType = userSettings.appPickerType))
+    val state: StateFlow<AppPickerUiState> = _state.asStateFlow()
+
+    fun onPickerTypeChanged(type: Int) {
+        userSettings.appPickerType = type
+        _state.update { it.copy(pickerType = type) }
+    }
+}

--- a/app/src/main/java/de/lemke/oneuisample/ui/AppPickerViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AppPickerViewModel.kt
@@ -1,13 +1,14 @@
 package de.lemke.oneuisample.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.data.UserSettingsRepository
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 data class AppPickerUiState(
     val pickerType: Int = 0,
@@ -17,11 +18,16 @@ data class AppPickerUiState(
 class AppPickerViewModel @Inject constructor(
     private val userSettings: UserSettingsRepository,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(AppPickerUiState(pickerType = userSettings.appPickerType))
-    val state: StateFlow<AppPickerUiState> = _state.asStateFlow()
+    val state: StateFlow<AppPickerUiState> =
+        userSettings.flow
+            .map { AppPickerUiState(pickerType = it.appPickerType) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = AppPickerUiState(pickerType = userSettings.appPickerType),
+            )
 
     fun onPickerTypeChanged(type: Int) {
         userSettings.appPickerType = type
-        _state.update { it.copy(pickerType = type) }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/AppPickerViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/AppPickerViewModel.kt
@@ -4,11 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.data.UserSettingsRepository
+import de.lemke.oneuisample.ui.util.stateInViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 
 data class AppPickerUiState(
     val pickerType: Int = 0,
@@ -21,11 +20,7 @@ class AppPickerViewModel @Inject constructor(
     val state: StateFlow<AppPickerUiState> =
         userSettings.flow
             .map { AppPickerUiState(pickerType = it.appPickerType) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = AppPickerUiState(pickerType = userSettings.appPickerType),
-            )
+            .stateInViewModel(viewModelScope, AppPickerUiState(pickerType = userSettings.appPickerType))
 
     fun onPickerTypeChanged(type: Int) {
         userSettings.appPickerType = type

--- a/app/src/main/java/de/lemke/oneuisample/ui/MainActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/MainActivity.kt
@@ -10,12 +10,14 @@ import com.google.android.material.appbar.model.ButtonModel
 import com.google.android.material.appbar.model.SuggestAppBarModel
 import com.google.android.material.appbar.model.view.SuggestAppBarView
 import dagger.hilt.android.AndroidEntryPoint
+import de.lemke.oneuisample.BuildConfig
 import de.lemke.oneuisample.BuildConfig.FIRST_RUN_SKIPPABLE
 import de.lemke.oneuisample.BuildConfig.VERSION_CODE
 import de.lemke.oneuisample.BuildConfig.VERSION_NAME
 import de.lemke.oneuisample.R
 import de.lemke.oneuisample.data.UserSettingsRepository
 import de.lemke.oneuisample.databinding.ActivityMainBinding
+import de.lemke.oneuisample.openLeakCanary
 import de.lemke.oneuisample.ui.fragments.FragmentBottomSheet
 import de.lemke.oneuisample.ui.util.configureSplashScreen
 import de.lemke.oneuisample.ui.util.finishWithFade
@@ -63,6 +65,7 @@ class MainActivity : AppCompatActivity() {
             // isImmersiveScroll = true
             setupNavigation(binding.bottomTab, binding.navigationHost.getFragment())
         }
+        binding.navigationView.findMenuItem(R.id.leaks_dest)?.isVisible = BuildConfig.DEBUG
         binding.navigationView.onNavigationSingleClick { item ->
             when (item.itemId) {
                 R.id.oobe_dest -> openOOBEAndFinish()
@@ -70,6 +73,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.about_custom_dest -> startActivity(Intent(this, CustomAboutActivity::class.java))
                 R.id.settings_dest -> startActivity(Intent(this, SettingsActivity::class.java))
                 R.id.bottom_sheet_dest -> FragmentBottomSheet().show(supportFragmentManager, null)
+                R.id.leaks_dest -> openLeakCanary(this)
                 else -> return@onNavigationSingleClick false
             }
             true

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
@@ -24,6 +24,7 @@ import de.lemke.oneuisample.BuildConfig
 import de.lemke.oneuisample.R
 import de.lemke.oneuisample.databinding.ActivityOobeBinding
 import de.lemke.oneuisample.ui.util.collectEvents
+import de.lemke.oneuisample.ui.util.collectState
 import dev.oneuiproject.oneui.widget.OnboardingTipsItemView
 
 @AndroidEntryPoint
@@ -40,6 +41,11 @@ class OOBEActivity : AppCompatActivity() {
         initTipsItems()
         initToSView()
         initFooterButton()
+        collectState(viewModel.isAccepting) { isAccepting ->
+            binding.oobeIntroFooterTosText.isEnabled = !isAccepting
+            binding.oobeIntroFooterButton.isVisible = !isAccepting
+            binding.oobeIntroFooterButtonProgress.isVisible = isAccepting
+        }
         collectEvents(viewModel.events) { event ->
             when (event) {
                 OOBEEvent.NavigateToMain -> navigateToMain()
@@ -98,11 +104,6 @@ class OOBEActivity : AppCompatActivity() {
 
     private fun initFooterButton() {
         if (resources.configuration.screenWidthDp < 360) binding.oobeIntroFooterButton.layoutParams.width = MATCH_PARENT
-        binding.oobeIntroFooterButton.setOnClickListener {
-            binding.oobeIntroFooterTosText.isEnabled = false
-            binding.oobeIntroFooterButton.isVisible = false
-            binding.oobeIntroFooterButtonProgress.isVisible = true
-            viewModel.onAcceptTos()
-        }
+        binding.oobeIntroFooterButton.setOnClickListener { viewModel.onAcceptTos() }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
@@ -15,29 +15,21 @@ import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout.LayoutParams
+import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.BuildConfig
 import de.lemke.oneuisample.R
-import de.lemke.oneuisample.data.UserSettingsRepository
 import de.lemke.oneuisample.databinding.ActivityOobeBinding
-import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
-import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
+import de.lemke.oneuisample.ui.util.collectEvents
 import dev.oneuiproject.oneui.widget.OnboardingTipsItemView
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class OOBEActivity : AppCompatActivity() {
     private lateinit var binding: ActivityOobeBinding
-
-    @Inject
-    lateinit var userSettings: UserSettingsRepository
+    private val viewModel: OOBEViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,6 +40,17 @@ class OOBEActivity : AppCompatActivity() {
         initTipsItems()
         initToSView()
         initFooterButton()
+        collectEvents(viewModel.events) { event ->
+            when (event) {
+                OOBEEvent.NavigateToMain -> navigateToMain()
+            }
+        }
+    }
+
+    private fun navigateToMain() {
+        startActivity(Intent(this, MainActivity::class.java))
+        @Suppress("DEPRECATION") if (Build.VERSION.SDK_INT < 34) overridePendingTransition(fade_in, fade_out)
+        finishAfterTransition()
     }
 
     private fun initTipsItems() {
@@ -99,15 +102,7 @@ class OOBEActivity : AppCompatActivity() {
             binding.oobeIntroFooterTosText.isEnabled = false
             binding.oobeIntroFooterButton.isVisible = false
             binding.oobeIntroFooterButtonProgress.isVisible = true
-            lifecycleScope.launch {
-                userSettings.acceptedTosVersion = resources.getInteger(R.integer.tos_version)
-                userSettings.lastVersionCode = intent.getIntExtra(EXTRA_VERSION_CODE, BuildConfig.VERSION_CODE)
-                userSettings.lastVersionName = intent.getStringExtra(EXTRA_VERSION_NAME) ?: BuildConfig.VERSION_NAME
-                delay(500.milliseconds)
-                startActivity(Intent(this@OOBEActivity, MainActivity::class.java))
-                @Suppress("DEPRECATION") if (Build.VERSION.SDK_INT < 34) overridePendingTransition(fade_in, fade_out)
-                finishAfterTransition()
-            }
+            viewModel.onAcceptTos()
         }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
@@ -19,13 +19,18 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.BuildConfig
 import de.lemke.oneuisample.R
 import de.lemke.oneuisample.databinding.ActivityOobeBinding
 import de.lemke.oneuisample.ui.util.collectEvents
 import de.lemke.oneuisample.ui.util.collectState
+import de.lemke.oneuisample.ui.util.finishWithFade
 import dev.oneuiproject.oneui.widget.OnboardingTipsItemView
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class OOBEActivity : AppCompatActivity() {
@@ -34,7 +39,10 @@ class OOBEActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (Build.VERSION.SDK_INT >= 34) overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, fade_in, fade_out)
+        if (Build.VERSION.SDK_INT >= 34) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, fade_in, fade_out)
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, fade_in, fade_out)
+        }
         binding = ActivityOobeBinding.inflate(layoutInflater)
         setContentView(binding.root)
         binding.root.setTitle(BuildConfig.APP_NAME)
@@ -54,9 +62,11 @@ class OOBEActivity : AppCompatActivity() {
     }
 
     private fun navigateToMain() {
-        startActivity(Intent(this, MainActivity::class.java))
-        @Suppress("DEPRECATION") if (Build.VERSION.SDK_INT < 34) overridePendingTransition(fade_in, fade_out)
-        finishAfterTransition()
+        lifecycleScope.launch {
+            delay(500.milliseconds)
+            startActivity(Intent(this@OOBEActivity, MainActivity::class.java))
+            finishWithFade()
+        }
     }
 
     private fun initTipsItems() {

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEActivity.kt
@@ -19,7 +19,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
-import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.BuildConfig
 import de.lemke.oneuisample.R
@@ -28,9 +27,6 @@ import de.lemke.oneuisample.ui.util.collectEvents
 import de.lemke.oneuisample.ui.util.collectState
 import de.lemke.oneuisample.ui.util.finishWithFade
 import dev.oneuiproject.oneui.widget.OnboardingTipsItemView
-import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class OOBEActivity : AppCompatActivity() {
@@ -62,11 +58,8 @@ class OOBEActivity : AppCompatActivity() {
     }
 
     private fun navigateToMain() {
-        lifecycleScope.launch {
-            delay(500.milliseconds)
-            startActivity(Intent(this@OOBEActivity, MainActivity::class.java))
-            finishWithFade()
-        }
+        startActivity(Intent(this, MainActivity::class.java))
+        finishWithFade()
     }
 
     private fun initTipsItems() {

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -1,5 +1,6 @@
 package de.lemke.oneuisample.ui
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,12 +10,12 @@ import de.lemke.oneuisample.domain.CompleteOnboardingUseCase
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
@@ -30,19 +31,30 @@ class OOBEViewModel @Inject constructor(
     private val versionCode = savedStateHandle.get<Int>(EXTRA_VERSION_CODE) ?: BuildConfig.VERSION_CODE
     private val versionName = savedStateHandle.get<String>(EXTRA_VERSION_NAME) ?: BuildConfig.VERSION_NAME
 
-    private val _events = Channel<OOBEEvent>(Channel.BUFFERED)
-    val events: ReceiveChannel<OOBEEvent> = _events
+    private val _events = MutableSharedFlow<OOBEEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<OOBEEvent> = _events.asSharedFlow()
 
     private val _isAccepting = MutableStateFlow(false)
     val isAccepting: StateFlow<Boolean> = _isAccepting.asStateFlow()
 
+    @Suppress("TooGenericExceptionCaught")
     fun onAcceptTos() {
         if (_isAccepting.value) return
         viewModelScope.launch {
             _isAccepting.value = true
-            completeOnboarding(versionCode, versionName)
-            delay(500.milliseconds)
-            _events.send(OOBEEvent.NavigateToMain)
+            try {
+                completeOnboarding(versionCode, versionName)
+                _events.emit(OOBEEvent.NavigateToMain)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "Onboarding failed — re-enabling button", e)
+                _isAccepting.value = false
+            }
         }
+    }
+
+    private companion object {
+        const val TAG = "OOBEViewModel"
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.BuildConfig
-import de.lemke.oneuisample.domain.AcceptTosUseCase
+import de.lemke.oneuisample.domain.CompleteOnboardingUseCase
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
 import javax.inject.Inject
@@ -25,7 +25,7 @@ sealed class OOBEEvent {
 @HiltViewModel
 class OOBEViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val acceptTos: AcceptTosUseCase,
+    private val completeOnboarding: CompleteOnboardingUseCase,
 ) : ViewModel() {
     private val versionCode = savedStateHandle.get<Int>(EXTRA_VERSION_CODE) ?: BuildConfig.VERSION_CODE
     private val versionName = savedStateHandle.get<String>(EXTRA_VERSION_NAME) ?: BuildConfig.VERSION_NAME
@@ -40,7 +40,7 @@ class OOBEViewModel @Inject constructor(
         if (_isAccepting.value) return
         viewModelScope.launch {
             _isAccepting.value = true
-            acceptTos(versionCode, versionName)
+            completeOnboarding(versionCode, versionName)
             delay(500.milliseconds)
             _events.send(OOBEEvent.NavigateToMain)
         }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -1,6 +1,5 @@
 package de.lemke.oneuisample.ui
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,7 +9,6 @@ import de.lemke.oneuisample.domain.CompleteOnboardingUseCase
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -37,24 +35,12 @@ class OOBEViewModel @Inject constructor(
     private val _isAccepting = MutableStateFlow(false)
     val isAccepting: StateFlow<Boolean> = _isAccepting.asStateFlow()
 
-    @Suppress("TooGenericExceptionCaught")
     fun onAcceptTos() {
         if (_isAccepting.value) return
         viewModelScope.launch {
             _isAccepting.value = true
-            try {
-                completeOnboarding(versionCode, versionName)
-                _events.emit(OOBEEvent.NavigateToMain)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.w(TAG, "Onboarding failed — re-enabling button", e)
-                _isAccepting.value = false
-            }
+            completeOnboarding(versionCode, versionName)
+            _events.emit(OOBEEvent.NavigateToMain)
         }
-    }
-
-    private companion object {
-        const val TAG = "OOBEViewModel"
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -11,7 +11,11 @@ import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 sealed class OOBEEvent {
@@ -26,13 +30,19 @@ class OOBEViewModel @Inject constructor(
     private val versionCode = savedStateHandle.get<Int>(EXTRA_VERSION_CODE) ?: BuildConfig.VERSION_CODE
     private val versionName = savedStateHandle.get<String>(EXTRA_VERSION_NAME) ?: BuildConfig.VERSION_NAME
 
-    val events = Channel<OOBEEvent>(Channel.BUFFERED)
+    private val _events = Channel<OOBEEvent>(Channel.BUFFERED)
+    val events: ReceiveChannel<OOBEEvent> = _events
+
+    private val _isAccepting = MutableStateFlow(false)
+    val isAccepting: StateFlow<Boolean> = _isAccepting.asStateFlow()
 
     fun onAcceptTos() {
+        if (_isAccepting.value) return
         viewModelScope.launch {
+            _isAccepting.value = true
             acceptTos(versionCode, versionName)
             delay(500.milliseconds)
-            events.send(OOBEEvent.NavigateToMain)
+            _events.send(OOBEEvent.NavigateToMain)
         }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -1,0 +1,38 @@
+package de.lemke.oneuisample.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lemke.oneuisample.BuildConfig
+import de.lemke.oneuisample.domain.AcceptTosUseCase
+import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
+import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+sealed class OOBEEvent {
+    data object NavigateToMain : OOBEEvent()
+}
+
+@HiltViewModel
+class OOBEViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val acceptTos: AcceptTosUseCase,
+) : ViewModel() {
+    private val versionCode = savedStateHandle.get<Int>(EXTRA_VERSION_CODE) ?: BuildConfig.VERSION_CODE
+    private val versionName = savedStateHandle.get<String>(EXTRA_VERSION_NAME) ?: BuildConfig.VERSION_NAME
+
+    val events = Channel<OOBEEvent>(Channel.BUFFERED)
+
+    fun onAcceptTos() {
+        viewModelScope.launch {
+            acceptTos(versionCode, versionName)
+            delay(500.milliseconds)
+            events.send(OOBEEvent.NavigateToMain)
+        }
+    }
+}

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -9,7 +9,9 @@ import de.lemke.oneuisample.domain.CompleteOnboardingUseCase
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -40,6 +42,7 @@ class OOBEViewModel @Inject constructor(
         viewModelScope.launch {
             _isAccepting.value = true
             completeOnboarding(versionCode, versionName)
+            delay(500.milliseconds)
             _events.send(OOBEEvent.NavigateToMain)
         }
     }

--- a/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/OOBEViewModel.kt
@@ -9,12 +9,12 @@ import de.lemke.oneuisample.domain.CompleteOnboardingUseCase
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_CODE
 import de.lemke.oneuisample.ui.util.EXTRA_VERSION_NAME
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 sealed class OOBEEvent {
@@ -29,8 +29,8 @@ class OOBEViewModel @Inject constructor(
     private val versionCode = savedStateHandle.get<Int>(EXTRA_VERSION_CODE) ?: BuildConfig.VERSION_CODE
     private val versionName = savedStateHandle.get<String>(EXTRA_VERSION_NAME) ?: BuildConfig.VERSION_NAME
 
-    private val _events = MutableSharedFlow<OOBEEvent>(extraBufferCapacity = 1)
-    val events: SharedFlow<OOBEEvent> = _events.asSharedFlow()
+    private val _events = Channel<OOBEEvent>(Channel.BUFFERED)
+    val events: Flow<OOBEEvent> = _events.receiveAsFlow()
 
     private val _isAccepting = MutableStateFlow(false)
     val isAccepting: StateFlow<Boolean> = _isAccepting.asStateFlow()
@@ -40,7 +40,7 @@ class OOBEViewModel @Inject constructor(
         viewModelScope.launch {
             _isAccepting.value = true
             completeOnboarding(versionCode, versionName)
-            _events.emit(OOBEEvent.NavigateToMain)
+            _events.send(OOBEEvent.NavigateToMain)
         }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/SettingsActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SettingsActivity.kt
@@ -57,6 +57,8 @@ class SettingsActivity : AppCompatActivity() {
         private lateinit var darkModePref: HorizontalRadioPreference
         private lateinit var autoDarkModePref: SwitchPreferenceCompat
         private val viewModel: SettingsViewModel by viewModels()
+        private lateinit var devOptionsPref: PreferenceCategory
+        private lateinit var switchScreenPref: SeslSwitchPreferenceScreen
 
         override fun onAttach(context: Context) {
             super.onAttach(context)
@@ -88,17 +90,19 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun render(state: SettingsUiState) {
-            findPreference<PreferenceCategory>("dev_options")?.isVisible = state.devModeEnabled
+            devOptionsPref.isVisible = state.devModeEnabled
             autoDarkModePref.isChecked = state.autoDarkMode
             darkModePref.isEnabled = !state.autoDarkMode
             darkModePref.value = if (state.darkMode) "1" else "0"
-            findPreference<SeslSwitchPreferenceScreen>("switch_screen")?.apply {
+            switchScreenPref.apply {
                 isChecked = state.sampleSwitchBar
                 summary = if (isChecked) "Enabled" else "Disabled"
             }
         }
 
         private fun initPreferences() {
+            devOptionsPref = findPreference("dev_options")!!
+            switchScreenPref = findPreference("switch_screen")!!
             initDarkModePrefs()
             initSwitchBarPref()
             initLanguagePref()
@@ -135,7 +139,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun initSwitchBarPref() {
-            findPreference<SeslSwitchPreferenceScreen>("switch_screen")?.apply {
+            switchScreenPref.apply {
                 onClick { startActivity(Intent(settingsActivity, SwitchBarActivity::class.java)) }
                 onNewValue { newValue ->
                     summary = if (newValue) "Enabled" else "Disabled"

--- a/app/src/main/java/de/lemke/oneuisample/ui/SettingsActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SettingsActivity.kt
@@ -56,9 +56,9 @@ class SettingsActivity : AppCompatActivity() {
         private lateinit var settingsActivity: SettingsActivity
         private lateinit var darkModePref: HorizontalRadioPreference
         private lateinit var autoDarkModePref: SwitchPreferenceCompat
-        private val viewModel: SettingsViewModel by viewModels()
         private lateinit var devOptionsPref: PreferenceCategory
         private lateinit var switchScreenPref: SeslSwitchPreferenceScreen
+        private val viewModel: SettingsViewModel by viewModels()
 
         override fun onAttach(context: Context) {
             super.onAttach(context)

--- a/app/src/main/java/de/lemke/oneuisample/ui/SettingsActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SettingsActivity.kt
@@ -17,6 +17,7 @@ import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
 import androidx.core.net.toUri
+import androidx.fragment.app.viewModels
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
@@ -25,8 +26,8 @@ import androidx.preference.SeslSwitchPreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.R
-import de.lemke.oneuisample.data.UserSettingsRepository
 import de.lemke.oneuisample.databinding.ActivitySettingsBinding
+import de.lemke.oneuisample.ui.util.collectState
 import de.lemke.oneuisample.ui.util.suggestiveSnackBar
 import dev.oneuiproject.oneui.ktx.addRelativeLinksCard
 import dev.oneuiproject.oneui.ktx.onClick
@@ -37,7 +38,6 @@ import dev.oneuiproject.oneui.preference.SuggestionCardPreference
 import dev.oneuiproject.oneui.preference.TipsCardPreference
 import dev.oneuiproject.oneui.preference.UpdatableWidgetPreference
 import dev.oneuiproject.oneui.widget.RelativeLink
-import javax.inject.Inject
 import dev.oneuiproject.oneui.design.R as designR
 
 @AndroidEntryPoint
@@ -56,9 +56,7 @@ class SettingsActivity : AppCompatActivity() {
         private lateinit var settingsActivity: SettingsActivity
         private lateinit var darkModePref: HorizontalRadioPreference
         private lateinit var autoDarkModePref: SwitchPreferenceCompat
-
-        @Inject
-        lateinit var userSettings: UserSettingsRepository
+        private val viewModel: SettingsViewModel by viewModels()
 
         override fun onAttach(context: Context) {
             super.onAttach(context)
@@ -86,27 +84,23 @@ class SettingsActivity : AppCompatActivity() {
             addRelativeLinksCard(
                 RelativeLink(getString(R.string.about_custom)) { startActivity(Intent(settingsActivity, CustomAboutActivity::class.java)) },
             )
+            collectState(viewModel.state) { render(it) }
         }
 
-        override fun onResume() {
-            super.onResume()
-            findPreference<PreferenceCategory>("dev_options")?.isVisible = userSettings.devModeEnabled
-            autoDarkModePref.isChecked = userSettings.autoDarkMode
-            darkModePref.isEnabled = !autoDarkModePref.isChecked
-            darkModePref.value = if (userSettings.darkMode) "1" else "0"
+        private fun render(state: SettingsUiState) {
+            findPreference<PreferenceCategory>("dev_options")?.isVisible = state.devModeEnabled
+            autoDarkModePref.isChecked = state.autoDarkMode
+            darkModePref.isEnabled = !state.autoDarkMode
+            darkModePref.value = if (state.darkMode) "1" else "0"
             findPreference<SeslSwitchPreferenceScreen>("switch_screen")?.apply {
-                onClick { startActivity(Intent(settingsActivity, SwitchBarActivity::class.java)) }
-                isChecked = userSettings.sampleSwitchBar
+                isChecked = state.sampleSwitchBar
                 summary = if (isChecked) "Enabled" else "Disabled"
-                onNewValue { newValue ->
-                    summary = if (newValue) "Enabled" else "Disabled"
-                    userSettings.sampleSwitchBar = newValue
-                }
             }
         }
 
         private fun initPreferences() {
             initDarkModePrefs()
+            initSwitchBarPref()
             initLanguagePref()
             initTosPref()
             initDeleteAppDataPref()
@@ -126,19 +120,28 @@ class SettingsActivity : AppCompatActivity() {
             darkModePref.onNewValue { newValue ->
                 val darkMode = newValue == "1"
                 AppCompatDelegate.setDefaultNightMode(if (darkMode) MODE_NIGHT_YES else MODE_NIGHT_NO)
-                userSettings.darkMode = darkMode
+                viewModel.onDarkModeChanged(darkMode)
             }
             autoDarkModePref.onNewValue { newValue ->
-                darkModePref.isEnabled = !newValue
                 if (newValue) {
                     AppCompatDelegate.setDefaultNightMode(MODE_NIGHT_FOLLOW_SYSTEM)
                 } else {
-                    AppCompatDelegate.setDefaultNightMode(if (userSettings.darkMode) MODE_NIGHT_YES else MODE_NIGHT_NO)
+                    AppCompatDelegate.setDefaultNightMode(if (viewModel.state.value.darkMode) MODE_NIGHT_YES else MODE_NIGHT_NO)
                 }
-                userSettings.autoDarkMode = newValue
+                viewModel.onAutoDarkModeChanged(newValue)
             }
             darkModePref.setDividerEnabled(false)
             darkModePref.setTouchEffectEnabled(false)
+        }
+
+        private fun initSwitchBarPref() {
+            findPreference<SeslSwitchPreferenceScreen>("switch_screen")?.apply {
+                onClick { startActivity(Intent(settingsActivity, SwitchBarActivity::class.java)) }
+                onNewValue { newValue ->
+                    summary = if (newValue) "Enabled" else "Disabled"
+                    viewModel.onSampleSwitchBarChanged(newValue)
+                }
+            }
         }
 
         private fun initLanguagePref() {

--- a/app/src/main/java/de/lemke/oneuisample/ui/SettingsViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SettingsViewModel.kt
@@ -1,0 +1,47 @@
+package de.lemke.oneuisample.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lemke.oneuisample.data.UserSettingsRepository
+import de.lemke.oneuisample.ui.util.stateInViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+
+data class SettingsUiState(
+    val darkMode: Boolean = false,
+    val autoDarkMode: Boolean = true,
+    val devModeEnabled: Boolean = false,
+    val sampleSwitchBar: Boolean = false,
+)
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val userSettings: UserSettingsRepository,
+) : ViewModel() {
+    val state: StateFlow<SettingsUiState> =
+        userSettings.flow
+            .map { SettingsUiState(it.darkMode, it.autoDarkMode, it.devModeEnabled, it.sampleSwitchBar) }
+            .stateInViewModel(
+                viewModelScope,
+                SettingsUiState(
+                    darkMode = userSettings.darkMode,
+                    autoDarkMode = userSettings.autoDarkMode,
+                    devModeEnabled = userSettings.devModeEnabled,
+                    sampleSwitchBar = userSettings.sampleSwitchBar,
+                ),
+            )
+
+    fun onDarkModeChanged(darkMode: Boolean) {
+        userSettings.darkMode = darkMode
+    }
+
+    fun onAutoDarkModeChanged(autoDarkMode: Boolean) {
+        userSettings.autoDarkMode = autoDarkMode
+    }
+
+    fun onSampleSwitchBarChanged(enabled: Boolean) {
+        userSettings.sampleSwitchBar = enabled
+    }
+}

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
@@ -41,10 +41,12 @@ class SwitchBarActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
     }
 
     private fun render(state: SwitchBarUiState) {
-        if (binding.root.switchBar.isChecked != state.enabled) {
-            binding.root.switchBar.removeOnSwitchChangeListener(this)
-            binding.root.switchBar.isChecked = state.enabled
-            binding.root.switchBar.addOnSwitchChangeListener(this)
+        binding.root.switchBar.apply {
+            if (isChecked != state.enabled) {
+                removeOnSwitchChangeListener(this@SwitchBarActivity)
+                isChecked = state.enabled
+                addOnSwitchChangeListener(this@SwitchBarActivity)
+            }
         }
         update(state.enabled)
     }

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
@@ -2,6 +2,7 @@ package de.lemke.oneuisample.ui
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SeslSwitchBar
 import androidx.appcompat.widget.SwitchCompat
@@ -12,37 +13,36 @@ import com.airbnb.lottie.model.KeyPath
 import com.airbnb.lottie.value.LottieValueCallback
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.oneuisample.R
-import de.lemke.oneuisample.data.UserSettingsRepository
 import de.lemke.oneuisample.databinding.ActivitySwitchbarBinding
+import de.lemke.oneuisample.ui.util.collectState
 import dev.oneuiproject.oneui.delegates.AppBarAwareYTranslator
 import dev.oneuiproject.oneui.delegates.ViewYTranslator
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class SwitchBarActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTranslator(), SeslSwitchBar.OnSwitchChangeListener {
     private lateinit var binding: ActivitySwitchbarBinding
-
-    @Inject
-    lateinit var userSettings: UserSettingsRepository
+    private val viewModel: SwitchBarViewModel by viewModels()
 
     @SuppressLint("RestrictedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySwitchbarBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        val enabled = userSettings.sampleSwitchBar
-        binding.root.switchBar.isChecked = enabled
-        update(enabled)
         binding.root.switchBar.addOnSwitchChangeListener(this)
         binding.switchBarExample.translateYWithAppBar(binding.root.appBarLayout, this)
+        collectState(viewModel.state) { render(it) }
     }
 
     override fun onSwitchChanged(
         switchCompat: SwitchCompat,
         enabled: Boolean,
     ) {
-        userSettings.sampleSwitchBar = enabled
-        update(enabled)
+        viewModel.onSwitchChanged(enabled)
+    }
+
+    private fun render(state: SwitchBarUiState) {
+        binding.root.switchBar.isChecked = state.enabled
+        update(state.enabled)
     }
 
     private fun update(enabled: Boolean) {

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
@@ -40,16 +40,13 @@ class SwitchBarActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
         viewModel.onSwitchChanged(enabled)
     }
 
-    private var lastRenderedEnabled: Boolean? = null
-
     private fun render(state: SwitchBarUiState) {
         if (binding.root.switchBar.isChecked != state.enabled) {
+            binding.root.switchBar.removeOnSwitchChangeListener(this)
             binding.root.switchBar.isChecked = state.enabled
+            binding.root.switchBar.addOnSwitchChangeListener(this)
         }
-        if (lastRenderedEnabled != state.enabled) {
-            lastRenderedEnabled = state.enabled
-            update(state.enabled)
-        }
+        update(state.enabled)
     }
 
     private fun update(enabled: Boolean) {

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
@@ -40,11 +40,16 @@ class SwitchBarActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
         viewModel.onSwitchChanged(enabled)
     }
 
+    private var lastRenderedEnabled: Boolean? = null
+
     private fun render(state: SwitchBarUiState) {
         if (binding.root.switchBar.isChecked != state.enabled) {
             binding.root.switchBar.isChecked = state.enabled
         }
-        update(state.enabled)
+        if (lastRenderedEnabled != state.enabled) {
+            lastRenderedEnabled = state.enabled
+            update(state.enabled)
+        }
     }
 
     private fun update(enabled: Boolean) {

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarActivity.kt
@@ -41,7 +41,9 @@ class SwitchBarActivity : AppCompatActivity(), ViewYTranslator by AppBarAwareYTr
     }
 
     private fun render(state: SwitchBarUiState) {
-        binding.root.switchBar.isChecked = state.enabled
+        if (binding.root.switchBar.isChecked != state.enabled) {
+            binding.root.switchBar.isChecked = state.enabled
+        }
         update(state.enabled)
     }
 

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarViewModel.kt
@@ -1,13 +1,14 @@
 package de.lemke.oneuisample.ui
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.data.UserSettingsRepository
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 data class SwitchBarUiState(
     val enabled: Boolean = false,
@@ -17,11 +18,16 @@ data class SwitchBarUiState(
 class SwitchBarViewModel @Inject constructor(
     private val userSettings: UserSettingsRepository,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(SwitchBarUiState(enabled = userSettings.sampleSwitchBar))
-    val state: StateFlow<SwitchBarUiState> = _state.asStateFlow()
+    val state: StateFlow<SwitchBarUiState> =
+        userSettings.flow
+            .map { SwitchBarUiState(enabled = it.sampleSwitchBar) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = SwitchBarUiState(enabled = userSettings.sampleSwitchBar),
+            )
 
     fun onSwitchChanged(enabled: Boolean) {
         userSettings.sampleSwitchBar = enabled
-        _state.update { it.copy(enabled = enabled) }
     }
 }

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarViewModel.kt
@@ -4,11 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lemke.oneuisample.data.UserSettingsRepository
+import de.lemke.oneuisample.ui.util.stateInViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 
 data class SwitchBarUiState(
     val enabled: Boolean = false,
@@ -21,11 +20,7 @@ class SwitchBarViewModel @Inject constructor(
     val state: StateFlow<SwitchBarUiState> =
         userSettings.flow
             .map { SwitchBarUiState(enabled = it.sampleSwitchBar) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = SwitchBarUiState(enabled = userSettings.sampleSwitchBar),
-            )
+            .stateInViewModel(viewModelScope, SwitchBarUiState(enabled = userSettings.sampleSwitchBar))
 
     fun onSwitchChanged(enabled: Boolean) {
         userSettings.sampleSwitchBar = enabled

--- a/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarViewModel.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/SwitchBarViewModel.kt
@@ -1,0 +1,27 @@
+package de.lemke.oneuisample.ui
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lemke.oneuisample.data.UserSettingsRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class SwitchBarUiState(
+    val enabled: Boolean = false,
+)
+
+@HiltViewModel
+class SwitchBarViewModel @Inject constructor(
+    private val userSettings: UserSettingsRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(SwitchBarUiState(enabled = userSettings.sampleSwitchBar))
+    val state: StateFlow<SwitchBarUiState> = _state.asStateFlow()
+
+    fun onSwitchChanged(enabled: Boolean) {
+        userSettings.sampleSwitchBar = enabled
+        _state.update { it.copy(enabled = enabled) }
+    }
+}

--- a/app/src/main/java/de/lemke/oneuisample/ui/fragments/TabDesign.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/fragments/TabDesign.kt
@@ -13,6 +13,11 @@ import de.lemke.oneuisample.ui.util.autoCleared
 class TabDesign : AbsBaseFragment(R.layout.fragment_tab_design) {
     private val binding by autoCleared { FragmentTabDesignBinding.bind(requireView()) }
 
+    override fun onDestroyView() {
+        view?.findViewById<ViewPager2>(R.id.viewPager2Design)?.adapter = null
+        super.onDestroyView()
+    }
+
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,

--- a/app/src/main/java/de/lemke/oneuisample/ui/util/LifecycleUtils.kt
+++ b/app/src/main/java/de/lemke/oneuisample/ui/util/LifecycleUtils.kt
@@ -24,8 +24,10 @@ import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /** Launches [block] in the lifecycle scope, repeating it whenever the lifecycle reaches [minActiveState]. */
@@ -62,20 +64,34 @@ inline fun <T> Fragment.collectState(
     flow.collect { onEach(it) }
 }
 
-/** Consumes events from [channel] and delivers each to [onEach] while the activity is at least [minActiveState]. */
+/** Collects [flow] events and delivers each to [onEach] while the activity is at least [minActiveState]. */
 inline fun <T> AppCompatActivity.collectEvents(
-    channel: ReceiveChannel<T>,
+    flow: Flow<T>,
     minActiveState: State = STARTED,
     crossinline onEach: (T) -> Unit,
 ) = launchAndRepeatWithLifecycle(minActiveState) {
-    for (event in channel) onEach(event)
+    flow.collect { onEach(it) }
 }
 
-/** Consumes events from [channel] and delivers each to [onEach] while the fragment view is at least [minActiveState]. */
+/** Collects [flow] events and delivers each to [onEach] while the fragment view is at least [minActiveState]. */
 inline fun <T> Fragment.collectEvents(
-    channel: ReceiveChannel<T>,
+    flow: Flow<T>,
     minActiveState: State = STARTED,
     crossinline onEach: (T) -> Unit,
 ) = launchAndRepeatWithViewLifecycle(minActiveState) {
-    for (event in channel) onEach(event)
+    flow.collect { onEach(it) }
 }
+
+/**
+ * Returns a [StateFlow] backed by this flow, using [SharingStarted.WhileSubscribed] with a
+ * 5-second timeout. Intended for ViewModel state derived from a repository flow.
+ */
+fun <T> Flow<T>.stateInViewModel(
+    scope: CoroutineScope,
+    initialValue: T,
+): StateFlow<T> =
+    stateIn(
+        scope = scope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = initialValue,
+    )

--- a/app/src/main/res/menu/menu_navigation.xml
+++ b/app/src/main/res/menu/menu_navigation.xml
@@ -48,4 +48,11 @@
         android:title="@string/settings"
         app:showAsAction="always" />
 
+    <item
+        android:id="@+id/leaks_dest"
+        android:icon="@drawable/ic_oui_tool_outline"
+        android:title="@string/memory_leaks"
+        android:visible="false"
+        app:showAsAction="always" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="face_widget_text">OneUI Sample App Face Widget</string>
     <string name="face_widget_text_aod">OneUI Sample App AOD Face Widget</string>
 
+    <string name="memory_leaks" translatable="false">Memory leaks</string>
     <string name="switch_bar_example">This is a SwitchBar example.</string>
 
     <string name="list">List</string>

--- a/app/src/release/java/de/lemke/oneuisample/DebugTools.kt
+++ b/app/src/release/java/de/lemke/oneuisample/DebugTools.kt
@@ -1,0 +1,6 @@
+package de.lemke.oneuisample
+
+import android.content.Context
+
+@Suppress("UnusedParameter")
+fun openLeakCanary(context: Context) = Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ ksp = "2.3.9"
 # Used via spotless { kotlin { ktlint(libs.versions.ktlint.get()) } } — version-only ref, no library/plugin alias
 #noinspection UnusedVersionCatalogEntry
 ktlint = "1.8.0"
+leakcanary = "2.14"
 lottie = "6.7.1"
 material3 = "1.4.0"
 oneui-design = "0.9.12+oneui8"
@@ -42,6 +43,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
 oneui-design = { module = "io.github.tribalfs:oneui-design", version.ref = "oneui-design" }
 oneui-icons = { module = "io.github.oneuiproject:icons", version.ref = "oneui-icons" }


### PR DESCRIPTION
## Summary

- Introduce `@HiltViewModel` per Activity that held mutable state or async business logic (`OOBEViewModel`, `AboutViewModel`, `SwitchBarViewModel`, `AppPickerViewModel`)
- Extract `AcceptTosUseCase` from `OOBEActivity` — async settings write + version update now survives rotation via `Channel.BUFFERED` event
- Activities slimmed to: inflate binding → `collectState` / `collectEvents` → forward interactions
- Add LeakCanary (`debugImplementation` only) with source-set split (`DebugTools.kt`) and drawer entry visible only in debug builds

## Test plan

- [ ] Open every screen, exercise all interactions
- [ ] Rotate device on each screen — no crash, state restored
- [ ] OOBE: tap accept, confirm navigation to MainActivity (test with rotation mid-delay)
- [ ] About: multi-tap version to toggle dev mode — label updates
- [ ] SwitchBar: toggle switch — Lottie animates, state persists across rotation
- [ ] AppPicker: change picker type — selection persists across rotation
- [ ] Debug build: "Memory leaks" drawer item visible and opens LeakCanary
- [ ] Release build: "Memory leaks" drawer item not visible
- [ ] `./gradlew spotlessCheck detekt` green
- [ ] `./gradlew lintDebug` green
- [ ] `./gradlew assembleDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
MVVM refactor: Add Hilt ViewModels (OOBE, About, SwitchBar, AppPicker, Settings) and move async/stateful logic into them (StateFlow UI states, Flow events). Extract CompleteOnboarding/AcceptTos use-case so onboarding persistence and nav delay survive rotation; OOBE uses a buffered Channel→Flow for events and an isAccepting StateFlow. Slim Activities to: inflate binding → collectState/collectEvents → forward interactions. Replace ReceiveChannel-based helpers with Flow-based collectEvents and add Flow.stateInViewModel utility. Add LeakCanary as a debug-only dependency with debug/release DebugTools stubs and a debug-only drawer entry. Minor fixes: guard switch listener re-entry, cache preference lookups, clear ViewPager2.adapter in onDestroyView. Test plan: exercise screens and interactions, verify rotation preserves state/no crashes (including OOBE accept during delay), About dev-mode multi-tap, SwitchBar/AppPicker persistence, debug vs release LeakCanary visibility; run spotlessCheck, detekt, lintDebug, assembleDebug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->